### PR TITLE
Additional implmements UT

### DIFF
--- a/source/concepts/implements.d
+++ b/source/concepts/implements.d
@@ -95,7 +95,7 @@ template implements(alias T, alias Interface) {
 }
 
 @("FooBar implements IFoo and IBar")
-unittest {
+@safe unittest {
     static assert(__traits(compiles, implements!(FooBar, IFoo)));
     static assert(__traits(compiles, implements!(FooBar, IBar)));
     

--- a/source/concepts/implements.d
+++ b/source/concepts/implements.d
@@ -111,6 +111,11 @@ template implements(alias T, alias Interface) {
     static assert(__traits(compiles, useFoo(FooClass.init)));
 }
 
+@("Foo implements FooAbstractClass")
+@safe unittest {
+    static assert(__traits(compiles, implements!(Foo, FooAbstractClass)));
+}
+
 version(unittest) {
 
     interface IFoo {
@@ -148,6 +153,11 @@ version(unittest) {
     class FooClass {
         int foo(int i, string s) @safe { return 0; }
         double lefoo(string s) @safe { return 0; }
+    }
+    
+    class FooAbstractClass {
+        abstract int foo(int i, string s) @safe;
+        final double lefoo(string s) @safe { return 0; }
     }
     
     void useFoo(T)(T) if(implements!(T, IFoo)) {}

--- a/source/concepts/implements.d
+++ b/source/concepts/implements.d
@@ -94,6 +94,17 @@ template implements(alias T, alias Interface) {
     static assert(__traits(compiles, useBar(Bar())));
 }
 
+@("FooBar implements IFoo and IBar")
+unittest {
+    static assert(__traits(compiles, implements!(FooBar, IFoo)));
+    static assert(__traits(compiles, implements!(FooBar, IBar)));
+    
+    static assert(__traits(compiles, useFoo(FooBar())));
+    static assert(__traits(compiles, useBar(FooBar())));
+    
+    static assert(__traits(compiles, useFooandBar(FooBar())));
+}
+
 version(unittest) {
 
     interface IFoo {
@@ -120,7 +131,15 @@ version(unittest) {
         string bar(double d) @system { return ""; }
         void bar(string s) @system { }
     }
+    
+    struct FooBar {
+        int foo(int i, string s) @safe { return 0; }
+        double lefoo(string s) @safe { return 0; }
+        string bar(double d) @safe { return ""; }
+        void bar(string s) @safe { }
+    }
 
     void useFoo(T)(T) if(implements!(T, IFoo)) {}
     void useBar(T)(T) if(implements!(T, IBar)) {}
+    void useFooandBar(T)(T) if(implements!(T, IFoo) && implements!(T, IBar)) {}
 }

--- a/source/concepts/implements.d
+++ b/source/concepts/implements.d
@@ -105,6 +105,12 @@ template implements(alias T, alias Interface) {
     static assert(__traits(compiles, useFooandBar(FooBar())));
 }
 
+@("FooClass implements IFoo")
+@safe unittest {
+    static assert(__traits(compiles, implements!(FooClass, IFoo)));
+    static assert(__traits(compiles, useFoo(FooClass.init)));
+}
+
 version(unittest) {
 
     interface IFoo {
@@ -138,7 +144,12 @@ version(unittest) {
         string bar(double d) @safe { return ""; }
         void bar(string s) @safe { }
     }
-
+    
+    class FooClass {
+        int foo(int i, string s) @safe { return 0; }
+        double lefoo(string s) @safe { return 0; }
+    }
+    
     void useFoo(T)(T) if(implements!(T, IFoo)) {}
     void useBar(T)(T) if(implements!(T, IBar)) {}
     void useFooandBar(T)(T) if(implements!(T, IFoo) && implements!(T, IBar)) {}


### PR DESCRIPTION
This adds some additional unittests for implements. In particular, the case where a struct may implement more than one interface (also ensuring everything works if there are more functions in the struct than a specific interface would require). 

EDIT: I added some additional unittests for classes and abstract classes. I'm not entirely sure the abstract class behavior makes sense, but it compiles as I've written it.