### PR TITLE
Add template constraints to implements

### DIFF
--- a/source/concepts/implements.d
+++ b/source/concepts/implements.d
@@ -1,10 +1,13 @@
 module concepts.implements;
 
+import std.traits : isAbstractClass, isAggregateType;
+
 alias Identity(alias T) = T;
 private enum isPrivate(T, string member) = !__traits(compiles, __traits(getMember, T, member));
 
 
-template implements(alias T, alias Interface) {
+template implements(alias T, alias Interface)
+    if (isAggregateType!T && isAbstractClass!Interface) {
 
     static if(__traits(compiles, check())) {
         bool implements() {


### PR DESCRIPTION
As far as I can tell, implements is designed to work with interfaces and abstract classes. This PR adds template constraints to ensure that is what are passed to it.